### PR TITLE
Postman fix that should work with render

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "dev": "nodemon src/app.js",
-    "start": "node src/app.js",
+    "start": "NODE_ENV=production node src/app.js",
     "format": "prettier --write \"src/**/*.js\""
   },
   "author": "",

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -61,7 +61,7 @@ const logout = async (req, res, next) => {
       signed: true,
       path: "/",
       sameSite: "none",
-      secure: true,
+      secure: process.env.NODE_ENV === "production",
     });
 
     res.status(StatusCodes.OK).json({ msg: "user logged out" });

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -13,7 +13,7 @@ const attachCookiesToResponse = ({ res, user }) => {
     signed: true,
     path: "/",
     sameSite: "none",
-    secure: true,
+    secure: process.env.NODE_ENV === "production",
   });
 };
 


### PR DESCRIPTION
## Description
Last change to have deployment to work on render.com had a side affect with the postman cookie not being able to be set to header. Issue seem to be in the `secure: true`. Cookie secure prop change to `process.env.NODE_ENV === "production"` instead of true and change _start_ script which is for prod to set the environment variable. 
<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? -->

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|   ✓ | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->


### After

<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria
Using dev script (`npm run dev`), postman should work normally on localhost. Deployment using start script which sets environment variable making cookie work.
<!-- Provide steps the other team members and mentors need to follow to properly test your additions. -->
